### PR TITLE
Volumes: Add a short-form specifier

### DIFF
--- a/seaworthy/dockerhelper.py
+++ b/seaworthy/dockerhelper.py
@@ -46,6 +46,13 @@ def _get_id_and_model(id_or_model, model_collection):
     return model.id, model
 
 
+def _parse_volume_short_form(short_form):
+    parts = short_form.split(':', 1)
+    bind = parts[0]
+    mode = parts[1] if len(parts) == 2 else 'rw'
+    return {'bind': bind, 'mode': mode}
+
+
 class DockerHelper:
     def __init__(self, namespace='test'):
         self._namespace = namespace
@@ -166,6 +173,12 @@ class DockerHelper:
             - A ``Volume`` model object
             - The name of a volume (str)
             - A path on the host to bind mount into the container (str)
+
+            The bind parameters, i.e. the values in the mapping, can be of
+            two types:
+            - A full bind specifier (dict), for example
+              ``{'bind': '/mnt', 'mode': 'rw'}``
+            - A "short-form" bind specifier (str), for example ``/mnt:rw``
         :param kwargs:
             Other parameters to create the container with.
         """
@@ -226,6 +239,12 @@ class DockerHelper:
             if vol_id in create_volumes:
                 raise ValueError(
                     "Volume '{}' specified more than once".format(vol_id))
+
+            # Short form of opts
+            if isinstance(opts, str):
+                opts = _parse_volume_short_form(opts)
+            # Else assume long form
+
             create_volumes[vol_id] = opts
         return create_volumes
 

--- a/seaworthy/tests-core/test_dockerhelper.py
+++ b/seaworthy/tests-core/test_dockerhelper.py
@@ -421,6 +421,42 @@ class TestDockerHelper(unittest.TestCase):
         self.assertEqual(mount['Destination'], '/vol')
         self.assertEqual(mount['Mode'], 'rw')
 
+    def test_container_volumes_short_form(self):
+        """
+        When a container is created, a volume can be specified to be mounted
+        using a short-form bind specfier. The mode can be specified, but if not
+        it defaults to read/write.
+        """
+        dh = self.make_helper()
+
+        # Default mode: rw
+        vol_default = dh.create_volume('default')
+        self.addCleanup(dh.remove_volume, vol_default)
+        con_default = dh.create_container(
+            'default', IMG, volumes={vol_default: '/vol'})
+        self.addCleanup(dh.remove_container, con_default)
+        mounts = con_default.attrs['Mounts']
+        self.assertEqual(len(mounts), 1)
+        [mount] = mounts
+        self.assertEqual(mount['Type'], 'volume')
+        self.assertEqual(mount['Name'], vol_default.name)
+        self.assertEqual(mount['Destination'], '/vol')
+        self.assertEqual(mount['Mode'], 'rw')
+
+        # Specific mode: ro
+        vol_mode = dh.create_volume('mode')
+        self.addCleanup(dh.remove_volume, vol_mode)
+        con_mode = dh.create_container(
+            'mode', IMG, volumes={vol_mode: '/mnt:ro'})
+        self.addCleanup(dh.remove_container, con_mode)
+        mounts = con_mode.attrs['Mounts']
+        self.assertEqual(len(mounts), 1)
+        [mount] = mounts
+        self.assertEqual(mount['Type'], 'volume')
+        self.assertEqual(mount['Name'], vol_mode.name)
+        self.assertEqual(mount['Destination'], '/mnt')
+        self.assertEqual(mount['Mode'], 'ro')
+
     def test_container_volumes_bind(self):
         """
         When a container is created, a bind mount can be specified in the


### PR DESCRIPTION
I'm not entirely certain about this design, but I think it definitely reduces boilerplate code when defining volumes to mount in a lot of cases.

The reason I'm not certain about this design is that it's one I've half made-up. It sits somewhere between docker-compose's short and long form. In docker-compose [the long-form](https://docs.docker.com/compose/compose-file/#long-syntax-3) is _kind of_ similar to the interface provided by the Docker Python SDK. The short-form that I'm inventing here is closer to the [docker-compose short-form](https://docs.docker.com/compose/compose-file/#short-syntax-3), but still shares some properties with the long-form.

In docker-compose the short-form is like:
```yaml
volumes:
  - my_volume:/mnt:rw
```

whereas here we keep things as a dict so that the volumes themselves don't have to be specified as strings, just the mountpoint:
```python
{ my_volume: '/mnt:rw' }
```

Hope this makes sense...