### PR TITLE
ContainerBase: Improve ports things

### DIFF
--- a/seaworthy/containers/base.py
+++ b/seaworthy/containers/base.py
@@ -149,8 +149,8 @@ class ContainerBase:
         Get the first mapping of the first (lowest) container port that has a
         mapping. Useful when a container publishes only one port.
 
-        Note that unlike the Docker API, which sorts ports alphabetically (e.g.
-        ``90/tcp`` > ``8000/tcp``), we sort ports numerically so that the
+        Note that unlike the Docker API, which sorts ports lexicographically
+        (e.g. ``90/tcp`` > ``8000/tcp``), we sort ports numerically so that the
         lowest port is always chosen.
         """
         mapped_ports = {p: m for p, m in self.ports.items() if m is not None}


### PR DESCRIPTION
* get_host_port default to TCP ports
* get_host_port returns a tuple of IP address, port
* ports property returns all port mappings
* get_first_host_port for easy host port lookup when there is only one port
* Much more error checking for when ports not exposed or published