### PR TITLE
 Try a slightly more drastic DockerHelper refactor 

### DIFF
--- a/seaworthy/dockerhelper.py
+++ b/seaworthy/dockerhelper.py
@@ -135,14 +135,14 @@ class ContainerHelper(HelperBase):
         }
 
         # Convert network & volume models to IDs
-        network = self._get_container_network(network, kwargs)
+        network = self._network_for_container(network, kwargs)
         if network is not None:
             network_id, network = (
                 self._networks_helper._get_id_and_model(network))
             create_kwargs['network'] = network_id
 
         if volumes:
-            create_kwargs['volumes'] = self._get_container_volumes(volumes)
+            create_kwargs['volumes'] = self._volumes_for_container(volumes)
 
         create_kwargs.update(kwargs)
 
@@ -153,7 +153,7 @@ class ContainerHelper(HelperBase):
 
         return container
 
-    def _get_container_network(self, network, create_kwargs):
+    def _network_for_container(self, network, create_kwargs):
         # If a network is specified use that
         if network is not None:
             return network
@@ -167,7 +167,7 @@ class ContainerHelper(HelperBase):
         # Else, use the default network
         return self._networks_helper.get_default()
 
-    def _get_container_volumes(self, volumes):
+    def _volumes_for_container(self, volumes):
         create_volumes = {}
         for vol, opts in volumes.items():
             try:

--- a/seaworthy/dockerhelper.py
+++ b/seaworthy/dockerhelper.py
@@ -326,9 +326,6 @@ class DockerHelper:
         self.containers = ContainerHelper(
             client, namespace, self.networks, self.volumes)
 
-    def setup(self):
-        pass
-
     def teardown(self):
         self.containers._teardown()
         self.networks._teardown()

--- a/seaworthy/dockerhelper.py
+++ b/seaworthy/dockerhelper.py
@@ -326,9 +326,6 @@ class DockerHelper:
         self.containers = ContainerHelper(
             client, namespace, self.networks, self.volumes)
 
-    def _resource_name(self, name):
-        return '{}_{}'.format(self._namespace, name)
-
     def setup(self):
         pass
 

--- a/seaworthy/dockerhelper.py
+++ b/seaworthy/dockerhelper.py
@@ -315,11 +315,11 @@ class VolumesHelper(HelperBase):
 
 
 class DockerHelper:
-    def __init__(self, client=None, namespace='test'):
+    def __init__(self, namespace='test', client=None):
+        self._namespace = namespace
         if client is None:
             client = docker.client.from_env()
         self._client = client
-        self._namespace = namespace
 
         self.networks = NetworksHelper(client, namespace)
         self.volumes = VolumesHelper(client, namespace)

--- a/seaworthy/dockerhelper.py
+++ b/seaworthy/dockerhelper.py
@@ -79,7 +79,7 @@ class HelperBase:
 
     def _teardown(self):
         for resource_id in self._ids.copy():
-            # Check if the network exists before trying to remove it
+            # Check if the resource exists before trying to remove it
             try:
                 resource = self.collection.get(resource_id)
             except docker.errors.NotFound:

--- a/seaworthy/dockerhelper.py
+++ b/seaworthy/dockerhelper.py
@@ -321,10 +321,10 @@ class DockerHelper:
             client = docker.client.from_env()
         self._client = client
 
-        self.networks = NetworksHelper(client, namespace)
-        self.volumes = VolumesHelper(client, namespace)
+        self.networks = NetworksHelper(self._client, namespace)
+        self.volumes = VolumesHelper(self._client, namespace)
         self.containers = ContainerHelper(
-            client, namespace, self.networks, self.volumes)
+            self._client, namespace, self.networks, self.volumes)
 
     def teardown(self):
         self.containers._teardown()

--- a/seaworthy/dockerhelper.py
+++ b/seaworthy/dockerhelper.py
@@ -58,7 +58,7 @@ class HelperBase:
             # Assume we have an ID string
             model = self.collection.get(id_or_model)
         else:
-            raise ValueError('Unexpected type {}, expected {} or {}'.format(
+            raise TypeError('Unexpected type {}, expected {} or {}'.format(
                 type(id_or_model), str, self.collection.model))
 
         return model.id, model

--- a/seaworthy/pytest/fixtures.py
+++ b/seaworthy/pytest/fixtures.py
@@ -25,7 +25,6 @@ def docker_helper_fixture(name='docker_helper', scope='module'):
         if 'PYTEST_XDIST_WORKER' in os.environ:
             prefix = '{}_{}'.format(prefix, os.environ['PYTEST_XDIST_WORKER'])
         docker_helper = DockerHelper(prefix)
-        docker_helper.setup()
         yield docker_helper
         docker_helper.teardown()
     return fixture

--- a/seaworthy/tests-core/containers/test_base.py
+++ b/seaworthy/tests-core/containers/test_base.py
@@ -24,7 +24,6 @@ class TestContainerBase(unittest.TestCase):
     def setUp(self):
         self.dh = DockerHelper()
         self.addCleanup(self.dh.teardown)
-        self.dh.setup()
 
         self.base = self.with_cleanup(ContainerBase(
             'wait', IMG_WAIT, docker_helper=self.dh))

--- a/seaworthy/tests-core/test_client.py
+++ b/seaworthy/tests-core/test_client.py
@@ -167,6 +167,7 @@ class TestContainerHttpClient(unittest.TestCase):
         self.addCleanup(container.stop_and_remove)
 
         client = ContainerHttpClient.for_container(container)
+        self.addCleanup(client.close)
 
         response = client.request('GET', ['foo'])
 
@@ -195,6 +196,7 @@ class TestContainerHttpClient(unittest.TestCase):
 
         client = ContainerHttpClient.for_container(
             container, container_port='8080')
+        self.addCleanup(client.close)
 
         response = client.request('GET', ['foo'])
 

--- a/seaworthy/tests-core/test_client.py
+++ b/seaworthy/tests-core/test_client.py
@@ -38,7 +38,6 @@ class TestContainerHttpClient(unittest.TestCase):
     def make_helper(self):
         dh = DockerHelper()
         self.addCleanup(dh.teardown)
-        dh.setup()
         return dh
 
     @responses.activate

--- a/seaworthy/tests-core/test_dockerhelper.py
+++ b/seaworthy/tests-core/test_dockerhelper.py
@@ -110,7 +110,7 @@ class TestDockerHelper(unittest.TestCase):
         There are no assertions here. We only care that calling teardown never
         raises any exceptions.
         """
-        dh = self.make_helper(setup=False)
+        dh = self.make_helper()
         # These should silently do nothing.
         dh.teardown()
         dh.teardown()

--- a/seaworthy/tests-core/test_dockerhelper.py
+++ b/seaworthy/tests-core/test_dockerhelper.py
@@ -391,7 +391,7 @@ class TestDockerHelper(unittest.TestCase):
         """
         dh = self.make_helper()
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(TypeError) as cm:
             dh.containers.create('invalid_type', IMG, network=42)
 
         self.assertEqual(
@@ -506,7 +506,7 @@ class TestDockerHelper(unittest.TestCase):
         """
         dh = self.make_helper()
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(TypeError) as cm:
             dh.containers.create(
                 'invalid_type', IMG,
                 volumes={42: {'bind': '/vol', 'mode': 'rw'}})

--- a/seaworthy/tests-core/test_dockerhelper.py
+++ b/seaworthy/tests-core/test_dockerhelper.py
@@ -29,15 +29,13 @@ class TestDockerHelper(unittest.TestCase):
         self.client = docker.client.from_env()
         self.addCleanup(self.client.api.close)
 
-    def make_helper(self, *args, setup=True, **kwargs):
+    def make_helper(self, *args, **kwargs):
         """
         Create and return a DockerHelper instance that will be cleaned up after
         the test.
         """
         dh = DockerHelper(*args, **kwargs)
         self.addCleanup(dh.teardown)
-        if setup:
-            dh.setup()
         return dh
 
     def list_networks(self, *args, namespace='test', **kw):
@@ -97,8 +95,7 @@ class TestDockerHelper(unittest.TestCase):
 
     def test_teardown_safe(self):
         """
-        DockerHelper.teardown() is safe to call multiple times, both before and
-        after setup.
+        DockerHelper.teardown() is safe to call multiple times.
 
         There are no assertions here. We only care that calling teardown never
         raises any exceptions.
@@ -106,12 +103,6 @@ class TestDockerHelper(unittest.TestCase):
         dh = self.make_helper(setup=False)
         # These should silently do nothing.
         dh.teardown()
-        dh.teardown()
-        # Run setup so we have something to tear down.
-        dh.setup()
-        # This should do the teardown.
-        dh.teardown()
-        # This should silently do nothing.
         dh.teardown()
 
     def test_teardown_containers(self):

--- a/seaworthy/tests-core/test_dockerhelper.py
+++ b/seaworthy/tests-core/test_dockerhelper.py
@@ -50,6 +50,16 @@ class TestDockerHelper(unittest.TestCase):
         return filter_by_name(
             self.client.volumes.list(*args, **kw), '{}_'.format(namespace))
 
+    def test_custom_client(self):
+        """
+        When the DockerHelper is created with a custom client, that client is
+        used.
+        """
+        client = docker.DockerClient(base_url='unix://var/run/docker.sock')
+        dh = self.make_helper(client=client)
+
+        self.assertIs(dh._client, client)
+
     def test_default_network_lifecycle(self):
         """
         The default network can only be created once and is removed during

--- a/seaworthy/tests-core/test_logs.py
+++ b/seaworthy/tests-core/test_logs.py
@@ -572,7 +572,6 @@ class TestWithRealContainer(unittest.TestCase, FakeAndRealContainerMixin):
     def setUp(self):
         self.dh = DockerHelper()
         self.addCleanup(self.dh.teardown)
-        self.dh.setup()
 
     def start_logging_container(self):
         script = '\n'.join([

--- a/seaworthy/tests/containers/test_provided.py
+++ b/seaworthy/tests/containers/test_provided.py
@@ -12,7 +12,6 @@ from seaworthy.pytest import dockertest
 @pytest.fixture(scope='class')
 def docker_helper():
     docker_helper = DockerHelper()
-    docker_helper.setup()
     yield docker_helper
     docker_helper.teardown()
 


### PR DESCRIPTION
* Make DockerHelper just take a Docker client at initialization, rather than one at setup
* Share common logic in HelperBase class
* Each helper only has access to as much as it needs
* Rename helpers
* Move some more methods from DockerHelper to ContainerHelper