### PR TITLE
Pin docker < 3.2.0 before we have a fix for log streaming

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'attrs',
-        'docker>=3,<4',
+        'docker>=3,<3.2',
         'hyperlink',
         'requests',
     ],


### PR DESCRIPTION
Requested by [at least one user](https://github.com/praekeltfoundation/seaworthy/issues/64#issuecomment-381111471) in #64.