### PR TITLE
Remove unused import in README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,6 @@ Write some tests in a file, for example, ``test_echo_container.py``:
 .. code-block:: python
 
     from seaworthy.definitions import ContainerDefinition
-    from seaworthy.pytest.fixtures import resource_fixture
 
     container = ContainerDefinition(
         'echo', 'jmalloc/echo-server',


### PR DESCRIPTION
At first I was confused by this line, then I realized it was not used.

I suggest we just remove it for clarity.