### PR TITLE
Fix RabbitMQContainer list operations with RabbitMQ 3.7.9+

### DIFF
--- a/docs/apigen.py
+++ b/docs/apigen.py
@@ -21,11 +21,16 @@ import shutil
 import sys
 from fnmatch import fnmatch
 from os import path
+from typing import Dict
 
 from sphinx import __display_version__
+from sphinx.application import Sphinx
 from sphinx.cmd.quickstart import EXTENSIONS
 from sphinx.util import logging
 from sphinx.util.osutil import FileAvoidWrite, walk
+
+if sys.version_info[0] >= 3:
+    unicode = str
 
 if False:
     # For type annotation

--- a/seaworthy/containers/rabbitmq.py
+++ b/seaworthy/containers/rabbitmq.py
@@ -87,11 +87,25 @@ class RabbitMQContainer(ContainerDefinition):
         cmd = ['rabbitmqctl'] + rabbitmqctl_opts + [command] + args
         return self.inner().exec_run(cmd)
 
+    def exec_rabbitmqctl_list(self, resources, args=[],
+                              rabbitmq_opts=['-q', '--no-table-headers']):
+        """
+        Execute a ``rabbitmqctl`` command to list the given resources.
+
+        :param resources: the resources to list, e.g. ``'vhosts'``
+        :param args: a list of args for the command
+        :param rabbitmqctl_opts:
+            a list of extra options to pass to ``rabbitmqctl``
+        :returns: a tuple of the command exit code and output
+        """
+        command = 'list_{}'.format(resources)
+        return self.exec_rabbitmqctl(command, args, rabbitmq_opts)
+
     def list_vhosts(self):
         """
         Run the ``list_vhosts`` command and return a list of vhost names.
         """
-        return output_lines(self.exec_rabbitmqctl('list_vhosts'))
+        return output_lines(self.exec_rabbitmqctl_list('vhosts'))
 
     def list_queues(self):
         """
@@ -103,7 +117,7 @@ class RabbitMQContainer(ContainerDefinition):
             the second is the current queue size.
         """
         lines = output_lines(
-            self.exec_rabbitmqctl('list_queues', ['-p', self.vhost]))
+            self.exec_rabbitmqctl_list('queues', ['-p', self.vhost]))
         return [tuple(line.split(None, 1)) for line in lines]
 
     def list_users(self):
@@ -115,7 +129,7 @@ class RabbitMQContainer(ContainerDefinition):
             A list of 2-element tuples. The first element is the username, the
             second a list of tags for the user.
         """
-        lines = output_lines(self.exec_rabbitmqctl('list_users'))
+        lines = output_lines(self.exec_rabbitmqctl_list('users'))
         return [_parse_rabbitmq_user(line) for line in lines]
 
     def broker_url(self):

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'sphinx_rtd_theme',
         ],
         'pep8test': [
-            'flake8',
+            'flake8>=3.7.0',
             'flake8-import-order',
             'pep8-naming',
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,6 @@ extras =
     testtools: testtools
     full: test
 deps =
-    # FIXME 2018-12-06: Dependency version conflict with requests/idna
-    # https://github.com/requests/requests/issues/4890
-    idna<2.8
     full: coverage
     pytest3: pytest>=3.0.0,<4
     pytest3: coverage


### PR DESCRIPTION
* Note that this breaks compatibility with RabbitMQ < 3.7.9